### PR TITLE
Add isActiveView check when adding banner

### DIFF
--- a/dist/ionic.content.banner.js
+++ b/dist/ionic.content.banner.js
@@ -146,7 +146,10 @@ angular.module('jett.ionic.content.banner', ['ionic']);
               return;
             }
 
-            getActiveView(body).querySelector('.scroll-content').appendChild(element[0]);
+            var scrollContents = getActiveView(body).querySelectorAll('.scroll-content')
+            Array.prototype.slice.call(scrollContents).filter(function (content) {
+              return isActiveView(content)
+            })[0].appendChild(element[0])
 
             ionic.requestAnimationFrame(function () {
               $timeout(function () {


### PR DESCRIPTION
I had a case where isActiveView were returning true in the getActiveView function although it was not active at the time of adding the banner. Adding the same check again did the trick.
